### PR TITLE
feat: add Rule and Map classes

### DIFF
--- a/miroslava/__init__.py
+++ b/miroslava/__init__.py
@@ -21,7 +21,9 @@ from miroslava.globals import current_app as current_app
 from miroslava.globals import g as g
 from miroslava.globals import request as request
 from miroslava.globals import session as session
+from miroslava.utils import abort as abort
 from miroslava.utils import jsonify as jsonify
+from miroslava.utils import make_response as make_response
 from miroslava.utils import render_template as render_template
 from miroslava.wrappers import Request as Request
 from miroslava.wrappers import Response as Response

--- a/miroslava/datastructures.py
+++ b/miroslava/datastructures.py
@@ -18,14 +18,11 @@ import typing as t
 from collections.abc import Iterable
 from collections.abc import Mapping
 
-from miroslava.utils import set_module as m
-
 K = t.TypeVar("K")
 V = t.TypeVar("V")
 T = t.TypeVar("T")
 
 
-@m("miroslava.twerkzeug.datastructures.structures")
 class MultiDict(dict[K, V]):
     """A dictionary variant that stores multiple values for each key.
 
@@ -137,7 +134,6 @@ class MultiDict(dict[K, V]):
                 yield key, values[0]
 
 
-@m("miroslava.twerkzeug.datastructures.headers")
 class Headers(MultiDict[str, str]):
     """HTTP header container that stores some header."""
 

--- a/miroslava/globals.py
+++ b/miroslava/globals.py
@@ -36,8 +36,6 @@ from contextvars import ContextVar
 from contextvars import Token
 from operator import attrgetter
 
-from miroslava.utils import set_module as m
-
 if t.TYPE_CHECKING:
     from collections.abc import Iterator
     from types import TracebackType
@@ -49,7 +47,6 @@ T = t.TypeVar("T")
 type SessionMixin = dict[str, t.Any]
 
 
-@m("miroslava.ctx")
 class _AppCtxGlobals:
     """Namespace object that stores arbitrary attributes."""
 
@@ -70,7 +67,6 @@ class _AppCtxGlobals:
         return iter(self.__dict__)
 
 
-@m("miroslava.ctx")
 class AppContext:
     """Application context carrying the app and a user namespace.
 
@@ -113,7 +109,6 @@ class AppContext:
             _cv_app.reset(self._cv_tokens.pop())
 
 
-@m("miroslava.ctx")
 class RequestContext:
     """Request context storing request and session state.
 
@@ -169,13 +164,11 @@ class RequestContext:
             _cv_request.reset(self._cv_tokens.pop())
 
 
-@m("miroslava.twerkzeug.local")
 def _identity[T](o: T) -> T:
     """Return itself."""
     return o
 
 
-@m("miroslava.twerkzeug.local")
 class LocalProxy[T]:
     """Proxy that forwards operations to a context-local object.
 

--- a/miroslava/wrappers.py
+++ b/miroslava/wrappers.py
@@ -27,7 +27,6 @@ from urllib.parse import parse_qsl
 
 from miroslava.datastructures import Headers
 from miroslava.datastructures import MultiDict
-from miroslava.utils import _get_server
 from miroslava.utils import get_content_type
 from miroslava.utils import get_current_url
 
@@ -105,6 +104,14 @@ HTTP_STATUS_CODES: dict[int, str] = {
     511: "Network Authentication Failed",
 }
 EnvironHeaders = Headers
+
+
+def _get_server(environ: WSGIEnvironment) -> tuple[str, int] | None:
+    """Return value of host and port details from environment."""
+    name = environ.get("SERVER_NAME")
+    if name is None:
+        return None
+    return name, int(environ.get("SERVER_PORT", 9001))
 
 
 class Request:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ extend-exclude = [
   "archive",
   "build",
   "dist",
+  "examples",
 ]
 
 [tool.ruff.lint]


### PR DESCRIPTION
- this adds support for
  - wrapper ``Rule`` and ``Map`` object
  - pattern matching type conversion (basic)
  - endpoint redirection based on dynamic routes
  - remove ``set_module`` as it breaks due to circular imports and doesn't add any actual value besides adding ``qualname``
  - ignore ``examples`` directory during tox builds